### PR TITLE
Feat: Hide subcategory/price for listing categories

### DIFF
--- a/components/Page/product/FormListing.vue
+++ b/components/Page/product/FormListing.vue
@@ -33,7 +33,7 @@
         </span></CustomDropdown
       >
     </div>
-    <div class="form__content__row">
+    <div v-if="!isListing" class="form__content__row">
       <CustomDropdown
         v-model="dataValue.product.selectSub"
         :is-in-valid="Boolean(dataValue.errors.sub)"
@@ -47,7 +47,7 @@
         </span></CustomDropdown
       >
     </div>
-    <div class="form__content__row">
+    <div v-if="!isListing" class="form__content__row">
       <CustomInput
         v-model="dataValue.product.price"
         type="number"
@@ -66,7 +66,7 @@
         class="form__content__row--input"
         :is-in-valid="Boolean(dataValue.errors.description)"
         :error-text="dataValue.errors.description"
-        placeholder="Details about your product."
+        :placeholder="isListing ? 'Tell us about your farm or business.' : 'Details about your product.'"
         @focus="dataValue.errors.description = null"
         ><span slot="label" class="form__content__row--label"
           >Description <strong>*</strong>
@@ -124,11 +124,15 @@ export default {
     categories() {
       return this.$store.getters["categories/categories"];
     },
+    isListing() {
+      return this.dataValue.product.selectsCategory?.isListing || false;
+    },
     selectsCategory() {
       return this.categories.map((item) => ({
         key: item.name,
         value: item.name,
         obj: item.subs,
+        isListing: item.isListing,
       }));
     },
     selectsSub() {
@@ -149,6 +153,9 @@ export default {
   methods: {
     handleChangeCategory() {
       this.dataValue.product.selectSub = null;
+      if (this.isListing) {
+        this.dataValue.product.price = null;
+      }
     },
   },
 };

--- a/pages/product/edit.vue
+++ b/pages/product/edit.vue
@@ -89,7 +89,7 @@ export default {
     this.formData.product.preview = this.editProduct.image;
     this.formData.product.delivery = this.editProduct.allowDelivery;
     this.formData.product.pickup = this.editProduct.allowPickup;
-    this.formData.product.price = Number(this.editProduct.price);
+    this.formData.product.price = this.editProduct.price != null ? Number(this.editProduct.price) : null;
     this.formData.product.description = this.editProduct.description;
     await this.$store.dispatch("categories/getCategories");
     this.setCategory();
@@ -102,28 +102,43 @@ export default {
       this.$router.go(-1);
     },
     setCategory() {
-      let res = {};
-      this.categories.forEach((item) => {
-        item.subs.forEach((sub) => {
-          if (sub.slug === this.editProduct.sub) {
-            this.formData.product.selectsCategory = {
-              key: item.slug,
-              value: item.name,
-              obj: item.subs,
-            };
-            this.formData.product.selectSub = {
-              key: sub.slug,
-              value: sub.name,
-            };
-          }
+      if (this.editProduct.sub) {
+        this.categories.forEach((item) => {
+          item.subs.forEach((sub) => {
+            if (sub.slug === this.editProduct.sub) {
+              this.formData.product.selectsCategory = {
+                key: item.name,
+                value: item.name,
+                obj: item.subs,
+                isListing: item.isListing,
+              };
+              this.formData.product.selectSub = {
+                key: sub.slug,
+                value: sub.name,
+              };
+            }
+          });
         });
-      });
+      } else {
+        // Listing category product (no subcategory) — match by checking isListing
+        const listingCat = this.categories.find((c) => c.isListing);
+        if (listingCat) {
+          this.formData.product.selectsCategory = {
+            key: listingCat.name,
+            value: listingCat.name,
+            obj: listingCat.subs,
+            isListing: true,
+          };
+        }
+      }
     },
     validate() {
       Object.values(this.formData.errors).forEach((key) => {
         this.formData.errors[key] = null;
       });
       let val = true;
+      const isListing =
+        this.formData.product.selectsCategory?.isListing || false;
 
       if (!this.formData.product.description) {
         this.formData.errors.description =
@@ -136,7 +151,7 @@ export default {
         val &= false;
       }
 
-      if (!this.formData.product.price) {
+      if (!isListing && !this.formData.product.price) {
         this.formData.errors.price = "Please enter a price of the listing.";
         val &= false;
       }
@@ -147,7 +162,7 @@ export default {
         val &= false;
       }
 
-      if (!this.formData.product.selectSub) {
+      if (!isListing && !this.formData.product.selectSub) {
         this.formData.errors.sub =
           "Please select a subcategory of the listing.";
         val &= false;
@@ -163,14 +178,20 @@ export default {
         return;
       }
 
+      const isListing =
+        this.formData.product.selectsCategory?.isListing || false;
+
       let data = {
         title: this.formData.product.title,
         delivery: this.formData.product.delivery,
         pickup: this.formData.product.pickup,
-        price: this.formData.product.price,
         description: this.formData.product.description,
-        subcategory: this.formData.product.selectSub.key,
       };
+
+      if (!isListing) {
+        data.price = this.formData.product.price;
+        data.subcategory = this.formData.product.selectSub.key;
+      }
 
       if (this.formData.product.file) data.image = this.formData.product.file;
 

--- a/pages/product/new.vue
+++ b/pages/product/new.vue
@@ -89,6 +89,8 @@ export default {
         this.formData.errors[key] = null;
       });
       let val = true;
+      const isListing =
+        this.formData.product.selectsCategory?.isListing || false;
 
       if (!this.formData.product.description) {
         this.formData.errors.description =
@@ -101,7 +103,7 @@ export default {
         val &= false;
       }
 
-      if (!this.formData.product.price) {
+      if (!isListing && !this.formData.product.price) {
         this.formData.errors.price = "Please enter a price of the listing.";
         val &= false;
       }
@@ -112,7 +114,7 @@ export default {
         val &= false;
       }
 
-      if (!this.formData.product.selectSub) {
+      if (!isListing && !this.formData.product.selectSub) {
         this.formData.errors.sub =
           "Please select a subcategory of the listing.";
         val &= false;
@@ -128,14 +130,20 @@ export default {
         return;
       }
 
+      const isListing =
+        this.formData.product.selectsCategory?.isListing || false;
+
       let data = {
         title: this.formData.product.title,
         delivery: this.formData.product.delivery,
         pickup: this.formData.product.pickup,
-        price: this.formData.product.price,
         description: this.formData.product.description,
-        subcategory: this.formData.product.selectSub.key,
       };
+
+      if (!isListing) {
+        data.price = this.formData.product.price;
+        data.subcategory = this.formData.product.selectSub.key;
+      }
 
       if (this.formData.product.file) data.image = this.formData.product.file;
       try {

--- a/utils/adapters/Category.js
+++ b/utils/adapters/Category.js
@@ -3,5 +3,6 @@ export default function (category) {
     name: category.name,
     image: category.image,
     subs: category.subcategories,
+    isListing: category.is_listing,
   };
 }


### PR DESCRIPTION
## Summary
- Passes `isListing` through Category adapter from API
- Hides subcategory and price fields in `FormListing` when selected category is a listing
- Skips subcategory/price validation and submission in both `new.vue` and `edit.vue` for listing categories
- Contextual description placeholder ("Tell us about your farm or business" vs "Details about your product")

## Test plan
- [ ] Select a listing category (e.g. Farms) — subcategory and price fields should disappear
- [ ] Select a non-listing category — subcategory and price fields should reappear
- [ ] Submit a farm listing without subcategory/price — should succeed
- [ ] Submit a regular listing without price — should show validation error
- [ ] Edit an existing farm listing — fields should stay hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)