### PR TITLE
Feat: Listing category filter in catalog

### DIFF
--- a/components/Page/catalog/FiltersCatalog.vue
+++ b/components/Page/catalog/FiltersCatalog.vue
@@ -40,7 +40,7 @@
       :key="index"
       v-model="selects[index]"
       :category="category"
-      :open-start="Boolean(query.subcategory)"
+      :open-start="Boolean(query.subcategory || query.category)"
       class="filter-container__category"
       @input="handleChangeSelect($event, index)"
     ></TheCategory>
@@ -112,17 +112,25 @@ export default {
       return this.$store.getters["cities"];
     },
     selectedSlugs() {
-      const obj = {};
+      const result = [];
       this.categories.forEach((item, index) => {
-        if (this.selects[index].length === 0) return;
+        if (!this.selects[index] || this.selects[index].length === 0) return;
 
-        obj[item.name] = item.subs
-          .filter((it, ind) => this.selects[index][ind])
-          .map(({ slug }) => {
-            return slug;
-          });
+        const hasSubs = item.subs && item.subs.length > 0;
+        if (!hasSubs) {
+          // Listing category — selected if selects[index][0] is true
+          if (this.selects[index][0]) {
+            result.push({ type: "category", slug: item.slug });
+          }
+        } else {
+          item.subs
+            .filter((it, ind) => this.selects[index][ind])
+            .forEach(({ slug }) => {
+              result.push({ type: "subcategory", slug });
+            });
+        }
       });
-      return obj;
+      return result;
     },
   },
   watch: {
@@ -177,6 +185,17 @@ export default {
           });
         });
       }
+      if (this.query.category) {
+        const categoryQuery = Array.isArray(this.query.category)
+          ? this.query.category
+          : [this.query.category];
+        this.categories.forEach((item, ind) => {
+          const hasSubs = item.subs && item.subs.length > 0;
+          if (!hasSubs && categoryQuery.includes(item.slug)) {
+            this.$set(this.selects[ind], 0, true);
+          }
+        });
+      }
       if (this.query.search) {
         this.searchInput = this.query.search;
       }
@@ -196,11 +215,9 @@ export default {
     },
     generateQuery() {
       let query = "";
-      Object.values(this.selectedSlugs).forEach((item, index) => {
-        item.forEach((key, index) => {
-          query +=
-            `subcategory=${key}` + (index !== item.length - 1 ? "&" : "");
-        });
+      this.selectedSlugs.forEach((item, index) => {
+        if (index > 0) query += "&";
+        query += `${item.type === "category" ? "category" : "subcategory"}=${item.slug}`;
       });
 
       if (this.searchInput) {

--- a/components/Page/catalog/FiltersCatalogMobile.vue
+++ b/components/Page/catalog/FiltersCatalogMobile.vue
@@ -64,7 +64,7 @@
           :key="index"
           v-model="selects[index]"
           :category="category"
-          :open-start="Boolean(query.subcategory)"
+          :open-start="Boolean(query.subcategory || query.category)"
           class="filter-container__category"
           @input="handleChangeSelect($event, index)"
         ></TheCategory>
@@ -137,17 +137,24 @@ export default {
       return this.$store.getters["cities"];
     },
     selectedSlugs() {
-      const obj = {};
+      const result = [];
       this.categories.forEach((item, index) => {
-        if (this.selects[index].length === 0) return;
+        if (!this.selects[index] || this.selects[index].length === 0) return;
 
-        obj[item.name] = item.subs
-          .filter((it, ind) => this.selects[index][ind])
-          .map(({ slug }) => {
-            return slug;
-          });
+        const hasSubs = item.subs && item.subs.length > 0;
+        if (!hasSubs) {
+          if (this.selects[index][0]) {
+            result.push({ type: "category", slug: item.slug });
+          }
+        } else {
+          item.subs
+            .filter((it, ind) => this.selects[index][ind])
+            .forEach(({ slug }) => {
+              result.push({ type: "subcategory", slug });
+            });
+        }
       });
-      return obj;
+      return result;
     },
   },
   watch: {
@@ -204,6 +211,16 @@ export default {
             }
           });
         });
+      } else if (this.query.category) {
+        const categoryQuery = Array.isArray(this.query.category)
+          ? this.query.category
+          : [this.query.category];
+        this.categories.forEach((item, ind) => {
+          const hasSubs = item.subs && item.subs.length > 0;
+          if (!hasSubs && categoryQuery.includes(item.slug)) {
+            this.$set(this.selects[ind], 0, true);
+          }
+        });
       } else {
         this.selects = this.categories.map((item) => []);
       }
@@ -236,11 +253,9 @@ export default {
     },
     generateQuery() {
       let query = "";
-      Object.values(this.selectedSlugs).forEach((item, index) => {
-        item.forEach((key, index) => {
-          query +=
-            `subcategory=${key}` + (index !== item.length - 1 ? "&" : "");
-        });
+      this.selectedSlugs.forEach((item, index) => {
+        if (index > 0) query += "&";
+        query += `${item.type === "category" ? "category" : "subcategory"}=${item.slug}`;
       });
 
       if (this.searchInput) {

--- a/components/Page/catalog/TheCategory.vue
+++ b/components/Page/catalog/TheCategory.vue
@@ -3,6 +3,8 @@
     <div
       :class="{ 'category-container__header--select': isSelect }"
       class="category-container__header"
+      :style="!hasSubs ? { cursor: 'pointer' } : {}"
+      @click="!hasSubs ? handleToggleListing() : null"
     >
       <img
         v-if="isSelect"
@@ -11,6 +13,7 @@
       />
       <p>{{ category.name }}</p>
       <div
+        v-if="hasSubs"
         class="category-container__header--arrow"
         :class="{ 'category-container__header--arrow--down': !isOpened }"
         @click="handleClickButton"
@@ -18,7 +21,7 @@
         <img src="@/assets/images/icons/arrow-up.svg" />
       </div>
     </div>
-    <div v-if="isOpened" class="category-container__main">
+    <div v-if="hasSubs && isOpened" class="category-container__main">
       <CustomCheckbox
         v-for="(sub, index) in category.subs"
         :key="index"
@@ -58,6 +61,9 @@ export default {
     };
   },
   computed: {
+    hasSubs() {
+      return this.category.subs && this.category.subs.length > 0;
+    },
     isSelect() {
       return this.selectedData.filter((item) => item).length > 0;
     },
@@ -80,6 +86,10 @@ export default {
   methods: {
     handleClickButton() {
       this.isOpened = !this.isOpened;
+    },
+    handleToggleListing() {
+      const isCurrentlySelected = this.selectedData[0] === true;
+      this.$emit("input", [!isCurrentlySelected]);
     },
     handleChangeValue() {
       this.$emit("input", this.selectedData);

--- a/components/Page/product/FormListing.vue
+++ b/components/Page/product/FormListing.vue
@@ -131,6 +131,7 @@ export default {
       return this.categories.map((item) => ({
         key: item.name,
         value: item.name,
+        slug: item.slug,
         obj: item.subs,
         isListing: item.isListing,
       }));

--- a/pages/product/edit.vue
+++ b/pages/product/edit.vue
@@ -109,6 +109,7 @@ export default {
               this.formData.product.selectsCategory = {
                 key: item.name,
                 value: item.name,
+                slug: item.slug,
                 obj: item.subs,
                 isListing: item.isListing,
               };
@@ -126,6 +127,7 @@ export default {
           this.formData.product.selectsCategory = {
             key: listingCat.name,
             value: listingCat.name,
+            slug: listingCat.slug,
             obj: listingCat.subs,
             isListing: true,
           };
@@ -188,7 +190,9 @@ export default {
         description: this.formData.product.description,
       };
 
-      if (!isListing) {
+      if (isListing) {
+        data.category = this.formData.product.selectsCategory.slug;
+      } else {
         data.price = this.formData.product.price;
         data.subcategory = this.formData.product.selectSub.key;
       }

--- a/pages/product/new.vue
+++ b/pages/product/new.vue
@@ -140,7 +140,9 @@ export default {
         description: this.formData.product.description,
       };
 
-      if (!isListing) {
+      if (isListing) {
+        data.category = this.formData.product.selectsCategory.slug;
+      } else {
         data.price = this.formData.product.price;
         data.subcategory = this.formData.product.selectSub.key;
       }

--- a/utils/adapters/Category.js
+++ b/utils/adapters/Category.js
@@ -1,6 +1,7 @@
 export default function (category) {
   return {
     name: category.name,
+    slug: category.slug,
     image: category.image,
     subs: category.subcategories,
     isListing: category.is_listing,

--- a/utils/data.js
+++ b/utils/data.js
@@ -19,6 +19,8 @@ export function generateFormDataProduct(data) {
 
   if (data.subcategory) formData.append("subcategory_slug", data.subcategory);
 
+  if (data.category) formData.append("category_slug", data.category);
+
   formData.append("allow_pickup", data.pickup);
 
   formData.append("allow_delivery", data.delivery);


### PR DESCRIPTION
## Summary
- Listing categories (e.g. Farms) now render as clickable/checkable rows in catalog filter — no empty dropdown
- TheCategory component hides the arrow toggle for listing categories and makes the header row directly clickable
- FiltersCatalog and FiltersCatalogMobile emit `category=<slug>` query params for listing categories
- Product creation and editing now sends `category_slug` for listing-type products
- Category adapter includes `slug`, FormListing passes `slug` to dropdown options

**Note:** Depends on backend PR https://github.com/anarchyincubator/eggslist-backend/pull/110 for the `slug` field in category API response and the `category` filter endpoint.

## Test plan
- [ ] Navigate to `/catalog` — listing categories (e.g. "Farms") show as clickable rows without arrows
- [ ] Clicking a listing category checks it (check icon + bold text) and filters products
- [ ] Regular categories still expand with subcategory checkboxes
- [ ] Selecting a listing category clears subcategory selections and vice versa
- [ ] URL updates with `category=<slug>` — page reload restores selection
- [ ] Create a product under a listing category — verify `category_slug` is sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)