### PR TITLE
Release March 5: Hide listing price dollar sign

### DIFF
--- a/components/Common/CardItem.vue
+++ b/components/Common/CardItem.vue
@@ -50,7 +50,7 @@
       </div>
     </div>
     <h4>{{ title }}</h4>
-    <div class="card__price body-1">${{ price }}</div>
+    <div v-if="price" class="card__price body-1">${{ price }}</div>
     <div v-if="authorConfig" class="card__author">
       <span>{{ authorConfig.firstName }}</span>
       <img

--- a/pages/catalog/product.vue
+++ b/pages/catalog/product.vue
@@ -61,7 +61,7 @@
             {{ product.title }}
           </h2>
 
-          <h3 class="product-page__description--price">${{ product.price }}</h3>
+          <h3 v-if="product.price" class="product-page__description--price">${{ product.price }}</h3>
           <div class="product-page__description--desc body-2">
             {{ product.description }}
           </div>


### PR DESCRIPTION
## Summary
- Hide the bare `$` that appears on listing-type products which have null prices
- Added `v-if` guards on price elements in `CardItem.vue` and `product.vue`

## Test plan
- [ ] Verify listing-type product pages no longer show a bare `$`
- [ ] Verify listing-type products in catalog list no longer show a bare `$`
- [ ] Verify normal products with prices still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)