### PR TITLE
Fix: Preserve description line breaks

### DIFF
--- a/pages/catalog/product.vue
+++ b/pages/catalog/product.vue
@@ -512,6 +512,7 @@ export default {
     }
     &--desc {
       margin-bottom: 1.5rem;
+      white-space: pre-line;
       @include layout-mobile() {
         margin-bottom: mvw(24px);
       }


### PR DESCRIPTION
## Summary
- Adds `white-space: pre-line` to the product description display on the product detail page
- This preserves user-entered line breaks that were previously collapsed by the browser

## Test plan
- [ ] Create a product with multi-line description (press Enter between paragraphs)
- [ ] View the product detail page and confirm line breaks are preserved
- [ ] Verify existing products with single-paragraph descriptions still look normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)