### PR TITLE
Release March 5: Preserve description line breaks

### DIFF
--- a/pages/catalog/product.vue
+++ b/pages/catalog/product.vue
@@ -512,6 +512,7 @@ export default {
     }
     &--desc {
       margin-bottom: 1.5rem;
+      white-space: pre-line;
       @include layout-mobile() {
         margin-bottom: mvw(24px);
       }


### PR DESCRIPTION
## Summary
- Adds `white-space: pre-line` CSS to product description display
- Preserves user-entered line breaks that were previously collapsed by the browser

## Test plan
- [ ] Create a product with multi-line description
- [ ] Confirm line breaks render correctly on the product detail page
- [ ] Verify existing single-paragraph descriptions are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)